### PR TITLE
Add `index.d.ts` file and module resolve setting

### DIFF
--- a/npm/index.d.ts
+++ b/npm/index.d.ts
@@ -1,0 +1,1 @@
+export * from './types/index';

--- a/npm/package.json
+++ b/npm/package.json
@@ -4,25 +4,46 @@
   "author": "InfiniteXyy",
   "license": "MIT",
   "main": "index.js",
-  "types": "types/index.d.ts",
+  "types": "index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "require": {
+        "types": "./index.d.ts",
+        "default": "./index.js"
+      },
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./esm/index.mjs"
+      },
       "types": "./index.d.ts",
       "module": "./esm/index.js",
-      "import": "./esm/index.mjs",
       "default": "./index.js"
     },
     "./effect": {
+      "require": {
+        "types": "./effect.d.ts",
+        "default": "./effect.js"
+      },
+      "import": {
+        "types": "./effect.d.ts",
+        "default": "./esm/effect.mjs"
+      },
       "types": "./effect.d.ts",
       "module": "./esm/effect.js",
-      "import": "./esm/effect.mjs",
       "default": "./effect.js"
     },
     "./tracked": {
-      "types": "./tracked.d.ts",
+      "require": {
+        "types": "./tracked.d.ts",
+        "default": "./tracked.js"
+      },
+      "import": {
+        "types": "./tracked.d.ts",
+        "default": "./esm/tracked.mjs"
+      },
+      "types": "./types/tracked.d.ts",
       "module": "./esm/tracked.js",
-      "import": "./esm/tracked.mjs",
       "default": "./tracked.js"
     }
   },


### PR DESCRIPTION
First of all, thanks for a nice package.

The reason for this PR is that the following error has occurred:
```
Could not find a declaration file for module 'zoov'. '$PROJECT_PATH/node_modules/.store/zoov-virtual-300f1217b1/node_modules/zoov/index.js' implicitly has an 'any' type.
  There are types at '$PROJECT_PATH/node_modules/zoov/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'zoov' library may need to update its package.json or typings.ts(7016)
```

There is no file `index.d.ts`.
https://www.npmjs.com/package/zoov?activeTab=code
![image](https://github.com/InfiniteXyy/zoov/assets/25581533/5632fab6-b3be-4e7a-a9bf-9ef601209256)

This patch is as follows:
- Add `index.d.ts`
- Support typescript5's [`moduleResolution`to `bundler`](https://dev.to/ayc0/typescript-50-new-mode-bundler-esm-1jic) https://github.com/microsoft/TypeScript/issues/52363
  If not, the following error may occur: https://github.com/nhn/tui.calendar/issues/1398
